### PR TITLE
Update to fix some  OpenAPI check  errors

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: "Bundesnetzagentur Strommarktdaten"
   
 servers:
-  - url: "https://www.smard.de/app/chart_data/"
+  - url: "https://www.smard.de/app/chart_data"
   
 paths:
   /{filter}/{region}/index_{resolution}.json:
@@ -15,7 +15,7 @@ paths:
         - $ref: '#/components/parameters/regionParameter'
         - $ref: '#/components/parameters/resolutionParameter'
       responses:
-        200:
+        '200':
           description: OK
           content: 
             application/json:
@@ -38,7 +38,7 @@ paths:
             type: integer
           required: true
       responses:
-        200:
+        '200':
           description: OK
           content:
             application/json:


### PR DESCRIPTION
- remove trailing slash for server-url
- replace response code numbers with strings

Could not fix multiple uses of parameter in paths./{filter}/{region}/{filter}_{region}_{resolution}_{timestamp}.json because API expects the same value for both filters 👎🏻